### PR TITLE
Fixed first launch trigger without internet

### DIFF
--- a/lib/src/palestine_connection_base.dart
+++ b/lib/src/palestine_connection_base.dart
@@ -17,7 +17,7 @@ class PalConnection {
   /// Timer object
   List<Timer?> timers = [null];
 
-  List<bool> prevConnectionStates = [false];
+  List<bool?> prevConnectionStates = [null];
 
   ///---
   /// initialize package
@@ -50,7 +50,7 @@ class PalConnection {
     required DomainCallback onConnectionLost,
     required DomainCallback onConnectionRestored,
   }) async {
-    prevConnectionStates = List.generate(domains.length, (index) => false);
+    prevConnectionStates = List.generate(domains.length, (index) => null);
     timers = List.generate(
       domains.length,
       (index) => Timer.periodic(


### PR DESCRIPTION
When launched with the Internet turned off, the event did not firing, because by default the status is already false. This fix makes it work the first time in any case, thus making it clear that the Internet is disabled without unnecessary checks.

_before_
Launch app > init lib > event(ONLINE ONLY)

_after_
Launch app > init lib > event(ONLINE/OFFLINE)